### PR TITLE
add `forbidden_dependency_binary!` options.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test/Binary.xcworkspace/contents.xcworkspacedata
 test/Binary.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
 test/Podfile
 test/Podfile.lock
+
+*.gem

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+fork for https://github.com/muukii/cocoapods-binary
+
+add `forbidden_dependency_binary!`, Prevent the automatic compilation of dependent libraries into binary as well.
+
+---
+
 > ⚠️ This is a temporaly forked repository.  
 
 https://github.com/leavez/cocoapods-binary/pull/137

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-fork for https://github.com/muukii/cocoapods-binary
+Forked from https://github.com/muukii/cocoapods-binary
 
 add `forbidden_dependency_binary!`, Prevent the automatic compilation of dependent libraries into binary as well.
 

--- a/lib/cocoapods-binary/Main.rb
+++ b/lib/cocoapods-binary/Main.rb
@@ -12,6 +12,11 @@ module Pod
                 DSL.prebuild_all = true
             end
 
+            # Fobidden dependency auto build to binary
+            def forbidden_dependency_binary!
+                DSL.forbidden_dependency_binary =  true
+            end
+
             # Enable bitcode for prebuilt frameworks
             def enable_bitcode_for_prebuilt_frameworks!
                 DSL.bitcode_enabled = true
@@ -56,6 +61,9 @@ module Pod
             end
 
             private
+            class_attr_accessor :forbidden_dependency_binary
+            forbidden_dependency_binary = false
+
             class_attr_accessor :prebuild_all
             prebuild_all = false
 

--- a/lib/cocoapods-binary/Prebuild.rb
+++ b/lib/cocoapods-binary/Prebuild.rb
@@ -109,6 +109,11 @@ module Pod
                 targets = self.pod_targets
             end
 
+            if Pod::Podfile::DSL.forbidden_dependency_binary 
+                forbidden_dependency_targets = targets.map {|t| t.recursive_dependent_targets }.flatten.uniq || []
+                targets = targets - forbidden_dependency_targets
+            end
+
             targets = targets.reject {|pod_target| sandbox.local?(pod_target.pod_name) }
 
             

--- a/lib/cocoapods-binary/gem_version.rb
+++ b/lib/cocoapods-binary/gem_version.rb
@@ -1,3 +1,3 @@
 module CocoapodsBinary
-    VERSION = "0.4.4"
+    VERSION = "0.4.5"
 end

--- a/lib/cocoapods-binary/helper/podfile_options.rb
+++ b/lib/cocoapods-binary/helper/podfile_options.rb
@@ -81,8 +81,11 @@ module Pod
                 if not Podfile::DSL.prebuild_all
                     targets = targets.select { |pod_target| prebuild_names.include?(pod_target.pod_name) } 
                 end
-                dependency_targets = targets.map {|t| t.recursive_dependent_targets }.flatten.uniq || []
-                targets = (targets + dependency_targets).uniq
+
+                if not Podfile::DSL.forbidden_dependency_binary
+                    dependency_targets = targets.map {|t| t.recursive_dependent_targets }.flatten.uniq || []
+                    targets = (targets + dependency_targets).uniq
+                end
 
                 # filter should not prebuild
                 explict_should_not_names = target_definition.should_not_prebuild_framework_pod_names


### PR DESCRIPTION
add `forbidden_dependency_binary!`, Prevent the automatic compilation of dependent libraries into binary as well.